### PR TITLE
Moved Plugin Textdomain and Added Class to Global Scope

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -165,4 +165,4 @@ class PluginName {
 } // end class
 
 // TODO: update the instantiation call of your plugin to the name given at the class definition
-new PluginName();
+$plugin_name = new PluginName();


### PR DESCRIPTION
The load_plugin_textdomain() function needs to be triggered via a function tied to the "init" (or similar) action in order to work fully with translation plugins like qTranslate or WPML.

When load_plugin_textdomain() is loaded outside of "init", translation strings aren't made available to the translation plugins.

When doing `new PluginName();` you should always set it to a variable; Check out Ott's answer on Stack exchange for an explanation: http://wordpress.stackexchange.com/questions/36013/remove-action-or-remove-filter-with-external-classes
