### PR TITLE
Added an uninstall hook

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -51,6 +51,7 @@ class PluginName {
 
 		register_activation_hook( __FILE__, array( $this, 'activate' ) );
 		register_deactivation_hook( __FILE__, array( $this, 'deactivate' ) );
+		register_uninstall_hook( __FILE__, array( $this, 'uninstall' ) );
 		
 	    /*
 	     * TODO:
@@ -86,6 +87,15 @@ class PluginName {
 		// TODO define deactivation functionality here		
 	} // end deactivate
 	
+	/**
+	 * Fired when the plugin is uninstalled.
+	 *
+	 * @params	$network_wide	True if WPMU superadmin uses "Network Activate" action, false if WPMU is disabled or plugin is activated on an individual blog 
+	 */
+	public function uninstall( $network_wide ) {
+		// TODO define uninstall functionality here		
+	} // end uninstall
+
 	/**
 	 * Loads the plugin text domain for translation
 	 */


### PR DESCRIPTION
Hey tom,

I saw on your blog, someone had commented that the boilerplate was missing an "uninstall.php" file for controlling the actions that take place during uninstall.

I added an PluginName::uninstall() method with a call to register_uninstall_hook() in the constructor. 

Thought it'd help

Thanks,

Greg
