### PR TITLE
A better way of loading language files

### DIFF
--- a/plugin-boilerplate/plugin.php
+++ b/plugin-boilerplate/plugin.php
@@ -103,8 +103,11 @@ class PluginName {
 	public function plugin_textdomain() {
 	
 		// TODO: replace "plugin-name-locale" with a unique value for your plugin
-		load_plugin_textdomain( 'plugin-name-locale', false, dirname( plugin_basename( __FILE__ ) ) . '/lang' );
-		
+		$domain = 'plugin-name-locale';
+		$locale = apply_filters( 'plugin_locale', get_locale(), $domain );
+        load_textdomain( $domain, WP_LANG_DIR.'/'.$domain.'/'.$domain.'-'.$locale.'.mo' );
+        load_plugin_textdomain( $domain, FALSE, dirname( plugin_basename( __FILE__ ) ) . '/lang/' );
+
 	} // end plugin_textdomain
 
 	/**


### PR DESCRIPTION
The patch attached means that users aren't restricted to placing translation files within the plugin's directory (Where they would be wiped out on plugin upgrade), but can also drop them under WP_LANG_DIR. A fuller description here:

http://www.geertdedeckere.be/article/loading-wordpress-language-files-the-right-way
