### PR TITLE
Fix loading textdomain when the plugin is symlinked

### DIFF
--- a/plugin-name/class-plugin-name.php
+++ b/plugin-name/class-plugin-name.php
@@ -135,7 +135,7 @@ class Plugin_Name {
 		$locale = apply_filters( 'plugin_locale', get_locale(), $domain );
 
 		load_textdomain( $domain, WP_LANG_DIR . '/' . $domain . '/' . $domain . '-' . $locale . '.mo' );
-		load_plugin_textdomain( $domain, FALSE, dirname( plugin_basename( __FILE__ ) ) . '/lang/' );
+		load_plugin_textdomain( $domain, FALSE, basename( dirname( __FILE__ ) ) . '/lang/' );
 	}
 
 	/**


### PR DESCRIPTION
plugin_basename doesn't return the correct path if the plugin is symlinked into webdir/wp-content/plugins/. This fixes the problem.
