### PR TITLE
Make WP_LANG_DIR constant safer

### DIFF
--- a/plugin-name/class-plugin-name.php
+++ b/plugin-name/class-plugin-name.php
@@ -139,7 +139,7 @@ class Plugin_Name {
 		$domain = $this->plugin_slug;
 		$locale = apply_filters( 'plugin_locale', get_locale(), $domain );
 
-		load_textdomain( $domain, WP_LANG_DIR . '/' . $domain . '/' . $domain . '-' . $locale . '.mo' );
+		load_textdomain( $domain, trailingslashit( WP_LANG_DIR ) . $domain . '/' . $domain . '-' . $locale . '.mo' );
 		load_plugin_textdomain( $domain, FALSE, basename( dirname( __FILE__ ) ) . '/lang/' );
 	}
 


### PR DESCRIPTION
We assume that someone defining WP_LANG_DIR will do so without a trailing slash, since we then add our own before adding in the rest of the path to the .mo file.

This change gets removes that assumption by removing our own slash from the string, and wrapping WP_LANG_DIR in trailingslashit() instead.
