### PR TITLE
Change default capability to 'manage_options'

### DIFF
--- a/plugin-name/class-plugin-name.php
+++ b/plugin-name/class-plugin-name.php
@@ -213,12 +213,13 @@ class Plugin_Name {
 		 *
 		 * Change 'Page Title' to the title of your plugin admin page
 		 * Change 'Menu Text' to the text for menu item for the plugin settings page
+		 * Change 'manage_options' to the capability you see fit (http://codex.wordpress.org/Roles_and_Capabilities)
 		 * Change 'plugin-name' to the name of your plugin
 		 */
 		$this->plugin_screen_hook_suffix = add_plugins_page(
 			__( 'Page Title', $this->plugin_slug ),
 			__( 'Menu Text', $this->plugin_slug ),
-			'read',
+			'manage_options',
 			$this->plugin_slug,
 			array( $this, 'display_plugin_admin_page' )
 		);


### PR DESCRIPTION
I am not sure if it's a good idea to use 'read' here, as more people will use the plugins page for options that subscribers... should never see.
I am not blaming you, it was me not paying attention but after migrating my plugin to this awesome boilerplate it ended up on WP.org with 'read' for the entire options page and people are now complaining ;)
