### PR TITLE
Removes reference to register_uninstall_hook from code comment

### DIFF
--- a/plugin-name/plugin-name.php
+++ b/plugin-name/plugin-name.php
@@ -33,6 +33,7 @@ if ( ! defined( 'WPINC' ) ) {
 require_once( plugin_dir_path( __FILE__ ) . 'class-plugin-name.php' );
 
 // Register hooks that are fired when the plugin is activated or deactivated.
+// When the plugin is deleted, the uninstall.php file is loaded.
 // TODO: replace Plugin_Name with the name of the plugin defined in `class-plugin-name.php`
 register_activation_hook( __FILE__, array( 'Plugin_Name', 'activate' ) );
 register_deactivation_hook( __FILE__, array( 'Plugin_Name', 'deactivate' ) );


### PR DESCRIPTION
Perhaps mention uninstall.php in stead?

```
// Register hooks that are fired when the plugin is activated or deactivated.
// When the plugin is deleted, the uninstall.php file is loaded.
```
