### PR TITLE
Patch 1

### DIFF
--- a/plugin-name/class-plugin-name.php
+++ b/plugin-name/class-plugin-name.php
@@ -103,7 +103,7 @@ class Plugin_Name {
 	public static function get_instance() {
 
 		// If the instance hasn't been set, set it now.
-		if ( !isset(static::$isntance) ) {
+		if ( !isset(static::$instance) ) {
 			static::$instance = new static();
 		}
 


### PR DESCRIPTION
I ran into an issue using the boilerplate when I needed to extend a class (I was using an autloader too, though I don't know if that makes a difference).

When trying to instantiate an extended class, the way the boilerplate is currently written, it seemed to create an object of the parent class. After spending some time on StackOverflow, it appeared that a slight alteration to your code to use the static method would solve the issue.

I updated the get_instance() method to reflect the changes.

This is my first time using github.. hopefully I'm doing this correctly
