### PR TITLE
Place options page under 'Settings' in stead of 'Plugins' menu

### DIFF
--- a/plugin-name/class-plugin-name.php
+++ b/plugin-name/class-plugin-name.php
@@ -296,13 +296,19 @@ class Plugin_Name {
 	public function add_plugin_admin_menu() {
 
 		/*
+		 * Add a settings page for this plugin to the Settings menu.
+		 *
+		 * NOTE:  Alternative menu locations are available via WordPress administration menu functions.
+		 *
+		 *        Administration Menus: http://codex.wordpress.org/Administration_Menus
+		 * 
 		 * TODO:
 		 *
 		 * Change 'Page Title' to the title of your plugin admin page
 		 * Change 'Menu Text' to the text for menu item for the plugin settings page
 		 * Change 'manage_options' to the capability you see fit (http://codex.wordpress.org/Roles_and_Capabilities)
 		 */
-		$this->plugin_screen_hook_suffix = add_plugins_page(
+		$this->plugin_screen_hook_suffix = add_options_page(
 			__( 'Page Title', $this->plugin_slug ),
 			__( 'Menu Text', $this->plugin_slug ),
 			'manage_options',
@@ -330,7 +336,7 @@ class Plugin_Name {
 
 		return array_merge(
 			array(
-				'settings' => '<a href="' . admin_url( 'plugins.php?page=' . $this->plugin_slug ) . '">' . __( 'Settings', $this->plugin_slug ) . '</a>'
+				'settings' => '<a href="' . admin_url( 'options-general.php?page=' . $this->plugin_slug ) . '">' . __( 'Settings', $this->plugin_slug ) . '</a>'
 			),
 			$links
 		);


### PR DESCRIPTION
The [Administration menu](http://codex.wordpress.org/Adding_Administration_Menus#Determining_Location_for_New_Menus) Codex article suggests that a 'Plugins' menu item

> Displays controls dealing with plugin management, not configuration options for a plugin itself.

Adding the options page under 'Settings' is probably a better choice. Fixes #60.
