### PR TITLE
Add trailing slash to language folder

### DIFF
--- a/plugin-name/class-plugin-name.php
+++ b/plugin-name/class-plugin-name.php
@@ -254,7 +254,7 @@ class Plugin_Name {
 		$locale = apply_filters( 'plugin_locale', get_locale(), $domain );
 
 		load_textdomain( $domain, trailingslashit( WP_LANG_DIR ) . $domain . '/' . $domain . '-' . $locale . '.mo' );
-		load_plugin_textdomain( $domain, FALSE, basename( dirname( __FILE__ ) ) . '/languages/' );
+		load_plugin_textdomain( $domain, FALSE, basename( dirname( __FILE__ ) ) . trailingslashit( '/languages' ) );
 
 	}
 


### PR DESCRIPTION
This is a must according to: http://codex.wordpress.org/Function_Reference/load_plugin_textdomain
