### PR TITLE
Fix $plugin_basename to allow plugin_action_links

### DIFF
--- a/plugin-name/admin/class-plugin-name-admin.php
+++ b/plugin-name/admin/class-plugin-name-admin.php
@@ -68,7 +68,7 @@ class Plugin_Name_Admin {
 		add_action( 'admin_menu', array( $this, 'add_plugin_admin_menu' ) );
 
 		// Add an action link pointing to the options page.
-		$plugin_basename = plugin_basename( plugin_dir_path( __FILE__ ) . $this->plugin_slug . '.php' );
+		$plugin_basename = plugin_basename( plugin_dir_path( __DIR__ ) . $this->plugin_slug . '.php' );
 		add_filter( 'plugin_action_links_' . $plugin_basename, array( $this, 'add_action_links' ) );
 
 		/*


### PR DESCRIPTION
With the move to /admin and /public directory, the class-plugin-name-admin.php needed to be changed to use **DIR** instead of **FILE** to create the $plugin_basename, otherwise the hook would be something like plugin_action_links_plugin-name/admin/plugin-name.php which doesn't work.
