### PR TITLE
Removed the trailing slash

### DIFF
--- a/plugin-name/public/class-plugin-name.php
+++ b/plugin-name/public/class-plugin-name.php
@@ -257,7 +257,7 @@ class Plugin_Name {
 		$locale = apply_filters( 'plugin_locale', get_locale(), $domain );
 
 		load_textdomain( $domain, trailingslashit( WP_LANG_DIR ) . $domain . '/' . $domain . '-' . $locale . '.mo' );
-		load_plugin_textdomain( $domain, FALSE, basename( plugin_dir_path( dirname( __FILE__ ) ) ) . '/languages/' );
+		load_plugin_textdomain( $domain, FALSE, basename( plugin_dir_path( dirname( __FILE__ ) ) ) . 'languages/' );
 
 	}
 


### PR DESCRIPTION
According to http://codex.wordpress.org/Function_Reference/plugin_dir_path, plugin_dir_path gets the filesystem directory path with trailing slash. Even tho two slashes will not cause an error, the extra slash can be removed.
