### PR TITLE
Add load_plugin_textdomain

### DIFF
--- a/plugin-name/public/class-plugin-name.php
+++ b/plugin-name/public/class-plugin-name.php
@@ -257,6 +257,7 @@ class Plugin_Name {
 		$locale = apply_filters( 'plugin_locale', get_locale(), $domain );
 
 		load_textdomain( $domain, trailingslashit( WP_LANG_DIR ) . $domain . '/' . $domain . '-' . $locale . '.mo' );
+		load_plugin_textdomain( $domain, FALSE, basename( plugin_dir_path( dirname( __FILE__ ) ) ) . '/languages/' );
 
 	}
 


### PR DESCRIPTION
If there is no `load_plugin_textdomain` then the translations will not be loaded from the languages folder.
