### PR TITLE
more instructions for using GitHub Updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,13 @@ Here's how to take advantage of this feature:
 3. Push commits to the master branch
 4. Enjoy your plugin being updated in the WordPress dashboard
 
-The current version of the GitHub Updater supports tags/branches - whichever has the highest number. It also supports different branches using the `GitHub Branch:` header. All that info is in [the project](https://github.com/afragen/github-updater)
+The current version of the GitHub Updater supports tags/branches - whichever has the highest number.
 
-In future versions, there will be steps to specify branches or tags rather than the `master` branch.
+To specify a branch that you would like to use for updating, just add a `GitHub Branch:` header. GitHub Updater will preferentially use a tag over a branch having the same or lesser version number. If the version number of the specified branch is greater then the update will pull from the branch and not from the tag.
+
+The default state is either `GitHub Branch: master` or nothing at all. They are equivalent.
+
+All that info is in [the project](https://github.com/afragen/github-updater).
 
 ## License
 

--- a/plugin-name/README.txt
+++ b/plugin-name/README.txt
@@ -107,6 +107,10 @@ You may provide arbitrary sections, in the same format as the ones above.  This 
 plugins where more information needs to be conveyed that doesn't fit into the categories of "description" or
 "installation."  Arbitrary sections will be shown below the built-in sections outlined above.
 
+== Updates ==
+
+This plugin supports the [GitHub Updater](https://github.com/afragen/github-updater) plugin, so if you install that, this plugin becomes automatically updateable direct from GitHub. Any submission to WP.org repo will make this redundant.
+
 == A brief Markdown Example ==
 
 Ordered list:


### PR DESCRIPTION
Added instructions to `README.md` for using branches and tags. Also added `Updater` section to `readme.txt` with basic instructions to users for installing GitHub Updater plugin for automatic updates. This should solve #93
