### PR TITLE
Depreciated Function

### DIFF
--- a/plugin-name/admin/views/admin.php
+++ b/plugin-name/admin/views/admin.php
@@ -15,7 +15,6 @@
 
 <div class="wrap">
 
-	<?php screen_icon(); ?>
 	<h2><?php echo esc_html( get_admin_page_title() ); ?></h2>
 
 	<!-- @TODO: Provide markup for your options page here. -->


### PR DESCRIPTION
Screen Icon function has been depreciated and CSS output is hidden in MP6. 
http://core.trac.wordpress.org/ticket/26119

screen_icon no longer returns anything as of WP 3.8: http://core.trac.wordpress.org/changeset/26537
