### PR TITLE
removed $plugin_basename fixed plugin_action_links

### DIFF
--- a/plugin-name/admin/class-plugin-name-admin.php
+++ b/plugin-name/admin/class-plugin-name-admin.php
@@ -77,8 +77,7 @@ class Plugin_Name_Admin {
 		add_action( 'admin_menu', array( $this, 'add_plugin_admin_menu' ) );
 
 		// Add an action link pointing to the options page.
-		$plugin_basename = plugin_basename( plugin_dir_path( __DIR__ ) . $this->plugin_slug . '.php' );
-		add_filter( 'plugin_action_links_' . $plugin_basename, array( $this, 'add_action_links' ) );
+		add_filter( 'plugin_action_links', array( $this, 'add_action_links' ) );
 
 		/*
 		 * Define custom functionality.


### PR DESCRIPTION
$plugin_basename was unnecessary, plugin_action_links is not well documented in the codex. (fixed)
