### PR TITLE
Replaced 'plugin' w/ 'plugin-name'

### DIFF
--- a/plugin-name/plugin-name.php
+++ b/plugin-name/plugin-name.php
@@ -69,7 +69,7 @@ add_action( 'plugins_loaded', array( 'Plugin_Name', 'get_instance' ) );
 /*
  * @TODO:
  *
- * - replace `class-plugin-admin.php` with the name of the plugin's admin file
+ * - replace `class-plugin-name-admin.php` with the name of the plugin's admin file
  * - replace Plugin_Name_Admin with the name of the class defined in
  *   `class-plugin-name-admin.php`
  *


### PR DESCRIPTION
Replacement `class-plugin-name-admin.php` for `class-plugin-admin.php` was made in `plugin-name.php` on line 72.  The change better allows find-replace functionality.
