### PR TITLE
enhance uninstall.php template

### DIFF
--- a/plugin-name/uninstall.php
+++ b/plugin-name/uninstall.php
@@ -13,5 +13,61 @@
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
-
-// @TODO: Define uninstall functionality here
+if (is_multisite()) {
+	global $wpdb;
+	$blogs = $wpdb->get_results("SELECT blog_id FROM {$wpdb->blogs}", ARRAY_A);
+		/* @TODO: delete all transient, options and files you may have added 
+		delete_transient( 'TRANSIENT_NAME' );
+		delete_option('OPTION_NAME');
+		//info: remove custom file directory for main site 
+		$upload_dir = wp_upload_dir();
+		$directory = $upload_dir['basedir'] . DIRECTORY_SEPARATOR . "CUSTOM_DIRECTORY_NAME" . DIRECTORY_SEPARATOR;
+		if (is_dir($directory)) {
+			foreach(glob($directory.'*.*') as $v){
+				unlink($v);
+			}
+			rmdir($directory);
+		}
+		*/
+	if ($blogs) {
+		foreach($blogs as $blog) {
+			switch_to_blog($blog['blog_id']);
+			/* @TODO: delete all transient, options and files you may have added 
+			delete_transient( 'TRANSIENT_NAME' );
+			delete_option('OPTION_NAME');
+			//info: remove custom file directory for main site 
+			$upload_dir = wp_upload_dir();
+			$directory = $upload_dir['basedir'] . DIRECTORY_SEPARATOR . "CUSTOM_DIRECTORY_NAME" . DIRECTORY_SEPARATOR;
+			if (is_dir($directory)) {
+				foreach(glob($directory.'*.*') as $v){
+					unlink($v);
+				}
+				rmdir($directory);
+			}
+			//info: remove and optimize tables
+			$GLOBALS['wpdb']->query("DROP TABLE `".$GLOBALS['wpdb']->prefix."TABLE_NAME`");
+			$GLOBALS['wpdb']->query("OPTIMIZE TABLE `" .$GLOBALS['wpdb']->prefix."options`");
+			*/
+			restore_current_blog();
+		}
+	}
+}
+else
+{
+	/* @TODO: delete all transient, options and files you may have added 
+	delete_transient( 'TRANSIENT_NAME' );
+	delete_option('OPTION_NAME');
+	//info: remove custom file directory for main site 
+	$upload_dir = wp_upload_dir();
+	$directory = $upload_dir['basedir'] . DIRECTORY_SEPARATOR . "CUSTOM_DIRECTORY_NAME" . DIRECTORY_SEPARATOR;
+	if (is_dir($directory)) {
+		foreach(glob($directory.'*.*') as $v){
+			unlink($v);
+		}
+		rmdir($directory);
+	}
+	//info: remove and optimize tables
+	$GLOBALS['wpdb']->query("DROP TABLE `".$GLOBALS['wpdb']->prefix."TABLE_NAME`");
+	$GLOBALS['wpdb']->query("OPTIMIZE TABLE `" .$GLOBALS['wpdb']->prefix."options`");
+	*/
+}


### PR DESCRIPTION
I use the follow code in my plugin "Leaflet Maps Marker" (http://wordpress.org/extend/plugins/leaflet-maps-marker/) to completely remove all traces of the plugin on uninstall (also deletes transient, options, custom database tables and files). The code also supports multisite uninstalls.
