### PR TITLE
Support PHP 5.2.x by dropping __DIR__

### DIFF
--- a/plugin-name/admin/class-plugin-name-admin.php
+++ b/plugin-name/admin/class-plugin-name-admin.php
@@ -77,7 +77,7 @@ class Plugin_Name_Admin {
 		add_action( 'admin_menu', array( $this, 'add_plugin_admin_menu' ) );
 
 		// Add an action link pointing to the options page.
-		$plugin_basename = plugin_basename( plugin_dir_path( __DIR__ ) . $this->plugin_slug . '.php' );
+		$plugin_basename = plugin_basename( plugin_dir_path( realpath( dirname( __FILE__ ) ) ) . $this->plugin_slug . '.php' );
 		add_filter( 'plugin_action_links_' . $plugin_basename, array( $this, 'add_action_links' ) );
 
 		/*


### PR DESCRIPTION
As per https://github.com/nextgenthemes/advanced-responsive-video-embedder/issues/7 I was informed that this would make my plugin work with PHP 5.2.x. I personally have not tested this code yet but I assume @andrejpavlovic did so I thought if this is the only thing that makes the Boilerplate require PHP 5.3 this might be a good change since WordPress itself only requires PHP 5.2.4.
