### PR TITLE
Fix wrong path for loading text domain

### DIFF
--- a/plugin-name/public/class-plugin-name.php
+++ b/plugin-name/public/class-plugin-name.php
@@ -257,7 +257,7 @@ class Plugin_Name {
 		$locale = apply_filters( 'plugin_locale', get_locale(), $domain );
 
 		load_textdomain( $domain, trailingslashit( WP_LANG_DIR ) . $domain . '/' . $domain . '-' . $locale . '.mo' );
-		load_plugin_textdomain( $domain, FALSE, basename( plugin_dir_path( dirname( __FILE__ ) ) ) . '/languages/' );
+		load_plugin_textdomain( $domain, FALSE, basename( plugin_dir_path( __FILE__ ) ) . '/languages/' );
 
 	}
 


### PR DESCRIPTION
The path returned before was `plugins/languages (as in .../wp-content/plugins/languages)` which is obviously wrong. I did have the plugin folder symlinked in `wp-content/plugins/` though. I tested my change with the plugin folder in place and symlinked and it works now.

https://codex.wordpress.org/Function_Reference/plugin_dir_path
