### PR TITLE
Move restore_current_blog in the correct position

### DIFF
--- a/plugin-name/public/class-plugin-name.php
+++ b/plugin-name/public/class-plugin-name.php
@@ -134,9 +134,9 @@ class Plugin_Name {
 
 					switch_to_blog( $blog_id );
 					self::single_activate();
-				}
 
-				restore_current_blog();
+					restore_current_blog();
+				}
 
 			} else {
 				self::single_activate();
@@ -172,9 +172,9 @@ class Plugin_Name {
 					switch_to_blog( $blog_id );
 					self::single_deactivate();
 
-				}
+					restore_current_blog();
 
-				restore_current_blog();
+				}
 
 			} else {
 				self::single_deactivate();


### PR DESCRIPTION
A fix for https://github.com/tommcfarlin/WordPress-Plugin-Boilerplate/issues/185

[Further documentation](http://codex.wordpress.org/Function_Reference/switch_to_blog#Multiple_switches)
