### PR TITLE
Add .editorconfig

### DIFF
--- a/plugin-name/.editorconfig
+++ b/plugin-name/.editorconfig
@@ -1,0 +1,21 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# http://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.json]
+indent_style = space
+indent_size = 2
+
+[*.txt,wp-config-sample.php]
+end_of_line = crlf


### PR DESCRIPTION
I added a default .editorconfig for my fork. Since the project is big on adhering to standards, an `.editorconfig` makes doing that really easy and would be good to include. If the dev's IDE isn't configured for it, nothing changes, so it's not a requirement or dependency, but just works for those it works with.

I also have a fork that scaffolds unit tests as well. It's basically just the result of running `wp scaffold plugin-tests` but I can open a PR if you'd like that as well. There isn't an functionality in the Boilerplate that I would test, now that the multisite logic from the previous version is gone. Do you want that too or no?
