### PR TITLE
Fixing require() vs require_once()

### DIFF
--- a/plugin-name/trunk/plugin-name.php
+++ b/plugin-name/trunk/plugin-name.php
@@ -50,7 +50,7 @@ register_deactivation_hook( __FILE__, array( 'Plugin_Name_Deactivator', 'deactiv
  * The core plugin class that is used to define internationalization,
  * dashboard-specific hooks, and public-facing site hooks.
  */
-require_once plugin_dir_path( __FILE__ ) . 'includes/class-plugin-name.php';
+require plugin_dir_path( __FILE__ ) . 'includes/class-plugin-name.php';
 
 /**
  * Begins execution of the plugin.


### PR DESCRIPTION
See : https://github.com/tommcfarlin/WordPress-Plugin-Boilerplate/issues/222. I believe this was in favor of doing it "correctly"? Should this be used for the other 2 Require_once() as well?
