### PR TITLE
Create functions for activation and deactivation hooks.

### DIFF
--- a/plugin-name/trunk/plugin-name.php
+++ b/plugin-name/trunk/plugin-name.php
@@ -32,19 +32,24 @@ if ( ! defined( 'WPINC' ) ) {
 
 /**
  * The code that runs during plugin activation.
+ * This action is documented in includes/class-plugin-name-activator.php
  */
-require_once plugin_dir_path( __FILE__ ) . 'includes/class-plugin-name-activator.php';
+function activate_plugin_name() {
+	require_once __DIR__ . 'includes/class-plugin-name-activator.php';
+	Plugin_Name_Activator::activate();
+}
 
 /**
  * The code that runs during plugin deactivation.
+ * This action is documented in includes/class-plugin-name-deactivator.php
  */
-require_once plugin_dir_path( __FILE__ ) . 'includes/class-plugin-name-deactivator.php';
+function deactivate_plugin_name() {
+	require_once __DIR__ . 'includes/class-plugin-name-deactivator.php';
+	Plugin_Name_Deactivator::deactivate();
+}
 
-/** This action is documented in includes/class-plugin-name-activator.php */
-register_activation_hook( __FILE__, array( 'Plugin_Name_Activator', 'activate' ) );
-
-/** This action is documented in includes/class-plugin-name-deactivator.php */
-register_deactivation_hook( __FILE__, array( 'Plugin_Name_Deactivator', 'deactivate' ) );
+register_activation_hook( __FILE__, 'activate_plugin_name' );
+register_deactivation_hook( __FILE__, 'deactivate_plugin_name' );
 
 /**
  * The core plugin class that is used to define internationalization,


### PR DESCRIPTION
Moving the activation and deactivation hooks into its own functions, makes so we dont have to include class-plugin-name-deactivator and class-plugin-name-activator on every page load.
