### PR TITLE
Make replacing the 'plugin_name' string without any complications.

### DIFF
--- a/plugin-name/trunk/admin/class-plugin-name-admin.php
+++ b/plugin-name/trunk/admin/class-plugin-name-admin.php
@@ -29,7 +29,7 @@ class Plugin_Name_Admin {
 	 * @access   private
 	 * @var      string    $plugin_name    The ID of this plugin.
 	 */
-	private $plugin_name;
+	private $plugin_slug;
 
 	/**
 	 * The version of this plugin.
@@ -47,9 +47,9 @@ class Plugin_Name_Admin {
 	 * @var      string    $plugin_name       The name of this plugin.
 	 * @var      string    $version    The version of this plugin.
 	 */
-	public function __construct( $plugin_name, $version ) {
+	public function __construct( $plugin_slug, $version ) {
 
-		$this->plugin_name = $plugin_name;
+		$this->plugin_slug = $plugin_slug;
 		$this->version = $version;
 
 	}
@@ -73,7 +73,7 @@ class Plugin_Name_Admin {
 		 * class.
 		 */
 
-		wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/plugin-name-admin.css', array(), $this->version, 'all' );
+		wp_enqueue_style( $this->plugin_slug, plugin_dir_url( __FILE__ ) . 'css/plugin-name-admin.css', array(), $this->version, 'all' );
 
 	}
 
@@ -96,7 +96,7 @@ class Plugin_Name_Admin {
 		 * class.
 		 */
 
-		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/plugin-name-admin.js', array( 'jquery' ), $this->version, false );
+		wp_enqueue_script( $this->plugin_slug, plugin_dir_url( __FILE__ ) . 'js/plugin-name-admin.js', array( 'jquery' ), $this->version, false );
 
 	}
 

--- a/plugin-name/trunk/includes/class-plugin-name.php
+++ b/plugin-name/trunk/includes/class-plugin-name.php
@@ -68,7 +68,7 @@ class Plugin_Name {
 	 */
 	public function __construct() {
 
-		$this->plugin_name = 'plugin-name';
+		$this->plugin_slug = 'plugin-slug';
 		$this->version = '1.0.0';
 
 		$this->load_dependencies();
@@ -135,7 +135,7 @@ class Plugin_Name {
 	private function set_locale() {
 
 		$plugin_i18n = new Plugin_Name_i18n();
-		$plugin_i18n->set_domain( $this->get_plugin_name() );
+		$plugin_i18n->set_domain( $this->get_plugin_slug() );
 
 		$this->loader->add_action( 'plugins_loaded', $plugin_i18n, 'load_plugin_textdomain' );
 
@@ -150,7 +150,7 @@ class Plugin_Name {
 	 */
 	private function define_admin_hooks() {
 
-		$plugin_admin = new Plugin_Name_Admin( $this->get_plugin_name(), $this->get_version() );
+		$plugin_admin = new Plugin_Name_Admin( $this->get_plugin_slug(), $this->get_version() );
 
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
@@ -166,7 +166,7 @@ class Plugin_Name {
 	 */
 	private function define_public_hooks() {
 
-		$plugin_public = new Plugin_Name_Public( $this->get_plugin_name(), $this->get_version() );
+		$plugin_public = new Plugin_Name_Public( $this->get_plugin_slug(), $this->get_version() );
 
 		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
 		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );

--- a/plugin-name/trunk/includes/class-plugin-name.php
+++ b/plugin-name/trunk/includes/class-plugin-name.php
@@ -46,7 +46,7 @@ class Plugin_Name {
 	 * @access   protected
 	 * @var      string    $plugin_name    The string used to uniquely identify this plugin.
 	 */
-	protected $plugin_name;
+	protected $plugin_slug;
 
 	/**
 	 * The current version of the plugin.
@@ -189,8 +189,8 @@ class Plugin_Name {
 	 * @since     1.0.0
 	 * @return    string    The name of the plugin.
 	 */
-	public function get_plugin_name() {
-		return $this->plugin_name;
+	public function get_plugin_slug() {
+		return $this->plugin_slug;
 	}
 
 	/**

--- a/plugin-name/trunk/public/class-plugin-name-public.php
+++ b/plugin-name/trunk/public/class-plugin-name-public.php
@@ -29,7 +29,7 @@ class Plugin_Name_Public {
 	 * @access   private
 	 * @var      string    $plugin_name    The ID of this plugin.
 	 */
-	private $plugin_name;
+	private $plugin_slug;
 
 	/**
 	 * The version of this plugin.
@@ -47,9 +47,9 @@ class Plugin_Name_Public {
 	 * @var      string    $plugin_name       The name of the plugin.
 	 * @var      string    $version    The version of this plugin.
 	 */
-	public function __construct( $plugin_name, $version ) {
+	public function __construct( $plugin_slug, $version ) {
 
-		$this->plugin_name = $plugin_name;
+		$this->plugin_slug = $plugin_slug;
 		$this->version = $version;
 
 	}
@@ -73,7 +73,7 @@ class Plugin_Name_Public {
 		 * class.
 		 */
 
-		wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/plugin-name-public.css', array(), $this->version, 'all' );
+		wp_enqueue_style( $this->plugin_slug, plugin_dir_url( __FILE__ ) . 'css/plugin-name-public.css', array(), $this->version, 'all' );
 
 	}
 
@@ -96,7 +96,7 @@ class Plugin_Name_Public {
 		 * class.
 		 */
 
-		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/plugin-name-public.js', array( 'jquery' ), $this->version, false );
+		wp_enqueue_script( $this->plugin_slug, plugin_dir_url( __FILE__ ) . 'js/plugin-name-public.js', array( 'jquery' ), $this->version, false );
 
 	}
 


### PR DESCRIPTION
Will fix the issue ending up with `get_somepluginname()` functions and properties when using string replacement  for the entire project as reported here: https://github.com/tommcfarlin/WordPress-Plugin-Boilerplate/issues/223#issuecomment-67569038

This also effects http://wppb.me/ since it now replaces the functions and class variables and this is not intended I guess.

Not sure why `slug` became `name` but changing it back to slug would make lives easier.