### PR TITLE
changed wording from "dashboard" to "admin area"

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Instead, the options are:
 ### Copying a Directory
 
 1. Copy the `trunk` directory into your `wp-content/plugins` directory. You may wish to rename this to something else.
-2. In the WordPress dashboard, navigation to the *Plugins* page
+2. In the WordPress admin area, navigation to the *Plugins* page
 Locate the menu item that reads “The WordPress Plugin Boilerplate.”
 3. Click on *Activate.*
 
@@ -37,7 +37,7 @@ Locate the menu item that reads “The WordPress Plugin Boilerplate.”
 
 1. Copy the `WordPress-Plugin-Boilerplate` directory into your `wp-content/plugins` directory.
 2. Create a symbolic link between the `trunk` directory and the plugin. For example: `ln -s plugin-name/trunk /path/to/wordpress/wp-content/plugins/plugin-name`
-3. In the WordPress dashboard, navigation to the *Plugins* page
+3. In the WordPress admin area, navigation to the *Plugins* page
 Locate the menu item that reads “The WordPress Plugin Boilerplate.”
 4. Click on *Activate.*
 
@@ -45,7 +45,7 @@ Locate the menu item that reads “The WordPress Plugin Boilerplate.”
 
 1. Copy the `WordPress-Plugin-Boilerplate` directory into your `wp-content/plugins` directory.
 2. Create a symbolic link between the `trunk` directory and the plugin. For example: `mklink /J path\to\wp-content\plugins \path\to\WordPress-Plugin-Boilerplate\trunk\plugin-name`
-3. In the WordPress dashboard, navigation to the *Plugins* page
+3. In the WordPress admin area, navigation to the *Plugins* page
 Locate the menu item that reads “The WordPress Plugin Boilerplate.”
 4. Click on *Activate.*
 
@@ -89,8 +89,8 @@ For reference, [here's a discussion](http://make.wordpress.org/themes/2013/03/04
 
 Note that if you include your own classes, or third-party libraries, there are three locations in which said files may go:
 
-* `plugin-name/includes` is where functionality shared between the dashboard and the public-facing parts of the side reside
-* `plugin-name/admin` is for all dashboard-specific functionality
+* `plugin-name/includes` is where functionality shared between the admin area and the public-facing parts of the site reside
+* `plugin-name/admin` is for all admin-specific functionality
 * `plugin-name/public` is for all public-facing functionality
 
 Note that previous versions of the Boilerplate did not include `Plugin_Name_Loader` but this class is used to register all filters and actions with WordPress.

--- a/plugin-name/trunk/admin/class-plugin-name-admin.php
+++ b/plugin-name/trunk/admin/class-plugin-name-admin.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * The dashboard-specific functionality of the plugin.
+ * The admin-specific functionality of the plugin.
  *
  * @link       http://example.com
  * @since      1.0.0
@@ -11,10 +11,10 @@
  */
 
 /**
- * The dashboard-specific functionality of the plugin.
+ * The admin-specific functionality of the plugin.
  *
  * Defines the plugin name, version, and two examples hooks for how to
- * enqueue the dashboard-specific stylesheet and JavaScript.
+ * enqueue the admin-specific stylesheet and JavaScript.
  *
  * @package    Plugin_Name
  * @subpackage Plugin_Name/admin
@@ -55,7 +55,7 @@ class Plugin_Name_Admin {
 	}
 
 	/**
-	 * Register the stylesheets for the Dashboard.
+	 * Register the stylesheets for the admin area.
 	 *
 	 * @since    1.0.0
 	 */
@@ -78,7 +78,7 @@ class Plugin_Name_Admin {
 	}
 
 	/**
-	 * Register the JavaScript for the dashboard.
+	 * Register the JavaScript for the admin area.
 	 *
 	 * @since    1.0.0
 	 */

--- a/plugin-name/trunk/admin/css/plugin-name-admin.css
+++ b/plugin-name/trunk/admin/css/plugin-name-admin.css
@@ -1,4 +1,4 @@
 /**
- * All of the CSS for your dashboard-specific functionality should be
+ * All of the CSS for your admin-specific functionality should be
  * included in this file.
  */

--- a/plugin-name/trunk/admin/js/plugin-name-admin.js
+++ b/plugin-name/trunk/admin/js/plugin-name-admin.js
@@ -2,7 +2,7 @@
 	'use strict';
 
 	/**
-	 * All of the code for your Dashboard-specific JavaScript source
+	 * All of the code for your admin-specific JavaScript source
 	 * should reside in this file.
 	 *
 	 * Note that this assume you're going to use jQuery, so it prepares

--- a/plugin-name/trunk/admin/partials/plugin-name-admin-display.php
+++ b/plugin-name/trunk/admin/partials/plugin-name-admin-display.php
@@ -1,9 +1,9 @@
 <?php
 
 /**
- * Provide a dashboard view for the plugin
+ * Provide a admin area view for the plugin
  *
- * This file is used to markup the public-facing aspects of the plugin.
+ * This file is used to markup the admin-facing aspects of the plugin.
  *
  * @link       http://example.com
  * @since      1.0.0

--- a/plugin-name/trunk/includes/class-plugin-name.php
+++ b/plugin-name/trunk/includes/class-plugin-name.php
@@ -4,7 +4,7 @@
  * The file that defines the core plugin class
  *
  * A class definition that includes attributes and functions used across both the
- * public-facing side of the site and the dashboard.
+ * public-facing side of the site and the admin area.
  *
  * @link       http://example.com
  * @since      1.0.0
@@ -16,7 +16,7 @@
 /**
  * The core plugin class.
  *
- * This is used to define internationalization, dashboard-specific hooks, and
+ * This is used to define internationalization, admin-specific hooks, and
  * public-facing site hooks.
  *
  * Also maintains the unique identifier of this plugin as well as the current
@@ -61,7 +61,7 @@ class Plugin_Name {
 	 * Define the core functionality of the plugin.
 	 *
 	 * Set the plugin name and the plugin version that can be used throughout the plugin.
-	 * Load the dependencies, define the locale, and set the hooks for the Dashboard and
+	 * Load the dependencies, define the locale, and set the hooks for the admin area and
 	 * the public-facing side of the site.
 	 *
 	 * @since    1.0.0
@@ -85,7 +85,7 @@ class Plugin_Name {
 	 *
 	 * - Plugin_Name_Loader. Orchestrates the hooks of the plugin.
 	 * - Plugin_Name_i18n. Defines internationalization functionality.
-	 * - Plugin_Name_Admin. Defines all hooks for the dashboard.
+	 * - Plugin_Name_Admin. Defines all hooks for the admin area.
 	 * - Plugin_Name_Public. Defines all hooks for the public side of the site.
 	 *
 	 * Create an instance of the loader which will be used to register the hooks
@@ -109,7 +109,7 @@ class Plugin_Name {
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-plugin-name-i18n.php';
 
 		/**
-		 * The class responsible for defining all actions that occur in the Dashboard.
+		 * The class responsible for defining all actions that occur in the admin area.
 		 */
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-plugin-name-admin.php';
 
@@ -142,7 +142,7 @@ class Plugin_Name {
 	}
 
 	/**
-	 * Register all of the hooks related to the dashboard functionality
+	 * Register all of the hooks related to the admin area functionality
 	 * of the plugin.
 	 *
 	 * @since    1.0.0

--- a/plugin-name/trunk/plugin-name.php
+++ b/plugin-name/trunk/plugin-name.php
@@ -4,7 +4,7 @@
  * The plugin bootstrap file
  *
  * This file is read by WordPress to generate the plugin information in the plugin
- * Dashboard. This file also includes all of the dependencies used by the plugin,
+ * admin area. This file also includes all of the dependencies used by the plugin,
  * registers the activation and deactivation functions, and defines a function
  * that starts the plugin.
  *
@@ -15,7 +15,7 @@
  * @wordpress-plugin
  * Plugin Name:       WordPress Plugin Boilerplate
  * Plugin URI:        http://example.com/plugin-name-uri/
- * Description:       This is a short description of what the plugin does. It's displayed in the WordPress dashboard.
+ * Description:       This is a short description of what the plugin does. It's displayed in the WordPress admin area.
  * Version:           1.0.0
  * Author:            Your Name or Your Company
  * Author URI:        http://example.com/
@@ -53,7 +53,7 @@ register_deactivation_hook( __FILE__, 'deactivate_plugin_name' );
 
 /**
  * The core plugin class that is used to define internationalization,
- * dashboard-specific hooks, and public-facing site hooks.
+ * admin-specific hooks, and public-facing site hooks.
  */
 require plugin_dir_path( __FILE__ ) . 'includes/class-plugin-name.php';
 

--- a/plugin-name/trunk/public/class-plugin-name-public.php
+++ b/plugin-name/trunk/public/class-plugin-name-public.php
@@ -14,7 +14,7 @@
  * The public-facing functionality of the plugin.
  *
  * Defines the plugin name, version, and two examples hooks for how to
- * enqueue the dashboard-specific stylesheet and JavaScript.
+ * enqueue the admin-specific stylesheet and JavaScript.
  *
  * @package    Plugin_Name
  * @subpackage Plugin_Name/public


### PR DESCRIPTION
> The dashboard is only the main admin page. The whole backend area is called the admin area.
https://github.com/tommcfarlin/WordPress-Plugin-Boilerplate/pull/265#issuecomment-74230781