### PR TITLE
Grant loader the power to remove hooks it has added.

### DIFF
--- a/plugin-name/includes/class-plugin-name-loader.php
+++ b/plugin-name/includes/class-plugin-name-loader.php
@@ -42,11 +42,20 @@ class Plugin_Name_Loader {
 	protected $filters;
 
 	/**
+	 *
+	 * @since 1.0.0
+	 * @access private
+	 * @var object|Plugin_Name_Loader
+	 */
+	private static $instance;
+
+	/**
 	 * Initialize the collections used to maintain the actions and filters.
 	 *
 	 * @since    1.0.0
+	 * @access private
 	 */
-	public function __construct() {
+	private function __construct() {
 
 		$this->actions = array();
 		$this->filters = array();
@@ -96,8 +105,7 @@ class Plugin_Name_Loader {
 	 * @return   type                                   The collection of actions and filters registered with WordPress.
 	 */
 	private function add( $hooks, $hook, $component, $callback, $priority, $accepted_args ) {
-
-		$hooks[] = array(
+		$hooks[ $this->hook_index( $hook, $component, $callback ) ] = array(
 			'hook'          => $hook,
 			'component'     => $component,
 			'callback'      => $callback,
@@ -108,6 +116,45 @@ class Plugin_Name_Loader {
 		return $hooks;
 
 	}
+
+	/**
+	 * Remove a hook.
+	 *
+	 * Hook must have been added by this class for this remover to work.
+	 *
+	 * Usage Plugin_Name_Loader::get_instance()->remove( $hook, $component, $callback );
+	 *
+	 * @since      1.0.0
+	 * @param      string               $hook             The name of the WordPress filter that is being registered.
+	 * @param      object               $component        A reference to the instance of the object on which the filter is defined.
+	 * @param      string               $callback         The name of the function definition on the $component.
+	 */
+	public function remove( $hook, $component, $callback ) {
+		$index = $this->hook_index( $hook, $component, $callback );
+		if( isset( $this->filters[ $index ]  ) ) {
+			remove_filter( $this->filters[ $index ][ 'hook' ],  array( $this->filters[ $index ][ 'component' ], $this->filters[ $index ][ 'callback' ] ) );
+		}
+
+		if( isset( $this->actions[ $index ] ) ) {
+			remove_action( $this->filters[ $index ][ 'hook' ],  array( $this->filters[ $index ][ 'component' ], $this->filters[ $index ][ 'callback' ] ) );
+		}
+	}
+
+	/**
+	 * Utility function for indexing $this->hooks
+	 *
+	 * @since       1.0.0
+	 * @access      protected
+	 * @param      string               $hook             The name of the WordPress filter that is being registered.
+	 * @param      object               $component        A reference to the instance of the object on which the filter is defined.
+	 * @param      string               $callback         The name of the function definition on the $component.
+	 *
+	 * @return string
+	 */
+	protected function hook_index( $hook, $component, $callback ) {
+		return md5( $hook . get_class( $component ) . $callback );
+	}
+
 
 	/**
 	 * Register the filters and actions with WordPress.
@@ -123,6 +170,22 @@ class Plugin_Name_Loader {
 		foreach ( $this->actions as $hook ) {
 			add_action( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
 		}
+
+
+	}
+
+	/**
+	 * Get an instance of this class
+	 *
+	 * @since 1.0.0
+	 * @return object|\Plugin_Name_Loader
+	 */
+	public static function get_instance() {
+		if( is_null( self::$instance ) ) {
+			self::$instance = new Plugin_Name_Loader();
+		}
+
+		return self::$instance;
 
 	}
 

--- a/plugin-name/includes/class-plugin-name.php
+++ b/plugin-name/includes/class-plugin-name.php
@@ -118,8 +118,11 @@ class Plugin_Name {
 		 * side of the site.
 		 */
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'public/class-plugin-name-public.php';
-
-		$this->loader = new Plugin_Name_Loader();
+		
+		/**
+		 * Get loader using its singleton
+		 */ 
+		$this->loader = Plugin_Name_Loader::get_instance();
 
 	}
 


### PR DESCRIPTION
PR for issue #336 

This PR introduces a new method into the Loader called remove. It removes a hook.

In order to do this I have made the following changes besides adding that method:
- I am now indexing the `filters`& `actions` properties of the loader class with a hash. Only way I could think of to easily get the right index of array without some sort of stupid foreach or other trickery. At first I just used hook name, but what if two callbacks are hooked to the same hook?
- I made the constructor of the loader class private and introduced a `get_instance()` method for getting an instance. This annoys me a little, but how else can we make sure that when you remove a hook, you're using the right object of the loader class then using a singleton?
- I used the aforementioned  `get_instance()` method in the main class to set the `loader` property since if I didn't there would be errors. Errors, as much as I like causing them, are bad.
