### PR TITLE
editorconfig file added to plugin folder

### DIFF
--- a/plugin-name/.editorconfig
+++ b/plugin-name/.editorconfig
@@ -1,0 +1,29 @@
+# WordPress Coding Standards editor configuration normalization 
+# http://make.wordpress.org/core/handbook/coding-standards/ 
+ 
+# This file is for unifying the coding style for different editors and IDEs 
+# editorconfig.org 
+ 
+# top-most EditorConfig file 
+root = true 
+  
+# Global 
+# UTF-8, Unix-style newlines, newline ending every file, trim trailing whitespace 
+[*] 
+charset = utf-8 
+end_of_line = lf 
+insert_final_newline = true 
+trim_trailing_whitespace = true 
+
+# PHP http://make.wordpress.org/core/handbook/coding-standards/php/ 
+# HTML http://make.wordpress.org/core/handbook/coding-standards/html/ 
+# CSS http://make.wordpress.org/core/handbook/coding-standards/css/ 
+# JavaScript http://make.wordpress.org/core/handbook/coding-standards/javascript/ 
+[*.php, *.css,*.scss, *.html, *.js]  
+indent_style = tab 
+indent_size = 4 
+
+# package.json uses spaces instead of tabs 
+[*.json] 
+indent_style = space 
+indent_size = 2 


### PR DESCRIPTION
EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs. The EditorConfig project consists of a file format for defining coding styles and a collection of text editor plugins that enable editors to read the file format and adhere to defined styles.

You can find EditorCOnfig project details from here: http://editorconfig.org/