### PR TITLE
Adding a version constant

### DIFF
--- a/plugin-name/includes/class-plugin-name.php
+++ b/plugin-name/includes/class-plugin-name.php
@@ -67,9 +67,12 @@ class Plugin_Name {
 	 * @since    1.0.0
 	 */
 	public function __construct() {
-
+		if ( defined( 'PLUGIN_VERSION' ) ) {
+			$this->version = PLUGIN_VERSION;
+		} else {
+			$this->version = '1.0.0';
+		}
 		$this->plugin_name = 'plugin-name';
-		$this->version = '1.0.0';
 
 		$this->load_dependencies();
 		$this->set_locale();

--- a/plugin-name/plugin-name.php
+++ b/plugin-name/plugin-name.php
@@ -30,6 +30,8 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
+define( PLUGIN_VERSION, '1.0.0' );
+
 /**
  * The code that runs during plugin activation.
  * This action is documented in includes/class-plugin-name-activator.php


### PR DESCRIPTION
Adds a PLUGIN_VERSION constant to the main plugin file. As this is usually the file where the version gets updated in the plugin header, it makes it easier to update the actual plugins version number in the same file.