### PR TITLE
Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,13 @@ The WordPress Plugin Boilerplate includes the following files:
 
 ## Installation
 
-The Boilerplate can be installed directly into your plugins folder "as-is". You will want to rename it and the classes inside of it to fit your needs.
+The Boilerplate can be installed directly into your plugins folder "as-is". You will want to rename it and the classes inside of it to fit your needs. For example, if your plugin is named 'example-me' then:
 
-Note that this will activate the source code of the Boilerplate, but because the Boilerplate has no real functionality there will be no menu items, meta boxes, or custom post types added.
+* rename files from `plugin_name` to `example_me`
+* change `plugin_name` to `example_me`
+* change `PLUGIN_NAME_` to `EXAMPLE_ME_`
+
+It's safe to activate the plugin at this point. Because the Boilerplate has no real functionality there will be no menu items, meta boxes, or custom post types added until you write the code.
 
 ## WordPress.org Preparation
 

--- a/plugin-name/plugin-name.php
+++ b/plugin-name/plugin-name.php
@@ -30,6 +30,11 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
+/**
+ * Currently pligin version.
+ * Start at version 1.0.0 and use SemVer - https://semver.org
+ * Rename this for your plugin and update it as you release new versions.
+ */
 define( 'PLUGIN_NAME_VERSION', '1.0.0' );
 
 /**


### PR DESCRIPTION
2 months ago you changed 

`define( 'PLUGIN_VERSION', '1.0.0' );`

to

`define( 'PLUGIN_NAME_VERSION', '1.0.0' );`

And suddenly 80% of the plugins submitted to WordPress.org using this boiler plate are missing that they need to rename that.

So ... This is my attempt to stem the tide :)