### PR TITLE
jQuery .load() is deprecated

### DIFF
--- a/plugin-name/admin/js/plugin-name-admin.js
+++ b/plugin-name/admin/js/plugin-name-admin.js
@@ -17,7 +17,7 @@
 	 *
 	 * When the window is loaded:
 	 *
-	 * $( window ).load(function() {
+	 * $( window ).on('load',function() {
 	 *
 	 * });
 	 *

--- a/plugin-name/public/js/plugin-name-public.js
+++ b/plugin-name/public/js/plugin-name-public.js
@@ -17,7 +17,7 @@
 	 *
 	 * When the window is loaded:
 	 *
-	 * $( window ).load(function() {
+	 * $( window ).on('load',function() {
 	 *
 	 * });
 	 *


### PR DESCRIPTION
[Deprecated since 1.8](https://api.jquery.com/category/deprecated/deprecated-1.8/) and [removed from 3.0](https://api.jquery.com/category/removed/)
jQuery `load` event should be used instead of `.load()` method