### PR TITLE
Enable adding componentless actions/filters

### DIFF
--- a/plugin-name/includes/class-plugin-name-loader.php
+++ b/plugin-name/includes/class-plugin-name-loader.php
@@ -117,11 +117,11 @@ class Plugin_Name_Loader {
 	public function run() {
 
 		foreach ( $this->filters as $hook ) {
-			add_filter( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
+			add_filter( $hook['hook'], $hook['component'] ? array( $hook['component'], $hook['callback'] ) : $hook['callback'], $hook['priority'], $hook['accepted_args'] );
 		}
 
 		foreach ( $this->actions as $hook ) {
-			add_action( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
+			add_action( $hook['hook'], $hook['component'] ? array( $hook['component'], $hook['callback'] ) : $hook['callback'], $hook['priority'], $hook['accepted_args'] );
 		}
 
 	}


### PR DESCRIPTION
This change allows WP's predefined filters/hooks to be added without a component. For example;

    add_filter( 'custom_menu_order', '__return_true' );

can be added with

    $this->loader->add_filter('custom_menu_order', null, '__return_true');