### PR TITLE
Added Prefix for codecanyon rejections

### DIFF
--- a/plugin-name/plugin-name.php
+++ b/plugin-name/plugin-name.php
@@ -41,7 +41,7 @@ define( 'PLUGIN_NAME_VERSION', '1.0.0' );
  * The code that runs during plugin activation.
  * This action is documented in includes/class-plugin-name-activator.php
  */
-function activate_plugin_name() {
+function plugin_name_activate_plugin_name() {
 	require_once plugin_dir_path( __FILE__ ) . 'includes/class-plugin-name-activator.php';
 	Plugin_Name_Activator::activate();
 }
@@ -50,13 +50,13 @@ function activate_plugin_name() {
  * The code that runs during plugin deactivation.
  * This action is documented in includes/class-plugin-name-deactivator.php
  */
-function deactivate_plugin_name() {
+function plugin_name_deactivate_plugin_name() {
 	require_once plugin_dir_path( __FILE__ ) . 'includes/class-plugin-name-deactivator.php';
 	Plugin_Name_Deactivator::deactivate();
 }
 
-register_activation_hook( __FILE__, 'activate_plugin_name' );
-register_deactivation_hook( __FILE__, 'deactivate_plugin_name' );
+register_activation_hook( __FILE__, 'plugin_name_activate_plugin_name' );
+register_deactivation_hook( __FILE__, 'plugin_name_deactivate_plugin_name' );
 
 /**
  * The core plugin class that is used to define internationalization,
@@ -73,10 +73,10 @@ require plugin_dir_path( __FILE__ ) . 'includes/class-plugin-name.php';
  *
  * @since    1.0.0
  */
-function run_plugin_name() {
+function plugin_name_run_plugin_name() {
 
 	$plugin = new Plugin_Name();
 	$plugin->run();
 
 }
-run_plugin_name();
+plugin_name_run_plugin_name();

--- a/plugin-name/plugin-name.php
+++ b/plugin-name/plugin-name.php
@@ -41,7 +41,7 @@ define( 'PLUGIN_NAME_VERSION', '1.0.0' );
  * The code that runs during plugin activation.
  * This action is documented in includes/class-plugin-name-activator.php
  */
-function plugin_name_activate_plugin_name() {
+function plugin_name_activate() {
 	require_once plugin_dir_path( __FILE__ ) . 'includes/class-plugin-name-activator.php';
 	Plugin_Name_Activator::activate();
 }
@@ -50,13 +50,13 @@ function plugin_name_activate_plugin_name() {
  * The code that runs during plugin deactivation.
  * This action is documented in includes/class-plugin-name-deactivator.php
  */
-function plugin_name_deactivate_plugin_name() {
+function plugin_name_deactivate() {
 	require_once plugin_dir_path( __FILE__ ) . 'includes/class-plugin-name-deactivator.php';
 	Plugin_Name_Deactivator::deactivate();
 }
 
-register_activation_hook( __FILE__, 'plugin_name_activate_plugin_name' );
-register_deactivation_hook( __FILE__, 'plugin_name_deactivate_plugin_name' );
+register_activation_hook( __FILE__, 'plugin_name_activate' );
+register_deactivation_hook( __FILE__, 'plugin_name_deactivate' );
 
 /**
  * The core plugin class that is used to define internationalization,
@@ -73,10 +73,10 @@ require plugin_dir_path( __FILE__ ) . 'includes/class-plugin-name.php';
  *
  * @since    1.0.0
  */
-function plugin_name_run_plugin_name() {
+function plugin_name_run() {
 
 	$plugin = new Plugin_Name();
 	$plugin->run();
 
 }
-plugin_name_run_plugin_name();
+plugin_name_run();


### PR DESCRIPTION
The functions or methods outside any class should be prefixed with the unique plugin name.Otherwise codecanyon soft rejects it.