### PR TITLE
Add support for shortcodes

### DIFF
--- a/plugin-name/includes/class-plugin-name-loader.php
+++ b/plugin-name/includes/class-plugin-name-loader.php
@@ -42,6 +42,15 @@ class Plugin_Name_Loader {
 	protected $filters;
 
 	/**
+	 * The array of shortcode registered with WordPress.
+	 *
+	 * @since    1.0.0
+	 * @access   protected
+	 * @var      array    $shortcodes    The shortcode registered with WordPress to fire when the plugin loads.
+	 */
+	protected $shortcodes;
+
+	/**
 	 * Initialize the collections used to maintain the actions and filters.
 	 *
 	 * @since    1.0.0
@@ -50,6 +59,7 @@ class Plugin_Name_Loader {
 
 		$this->actions = array();
 		$this->filters = array();
+		$this->shortcodes = array();
 
 	}
 
@@ -80,6 +90,18 @@ class Plugin_Name_Loader {
 	public function add_filter( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
 		$this->filters = $this->add( $this->filters, $hook, $component, $callback, $priority, $accepted_args );
 	}
+
+	/**
+   * Add a new shortcode to the collection to be registered with WordPress
+   *
+   * @since     1.0.0
+   * @param     string        $tag           The name of the new shortcode.
+   * @param     object        $component      A reference to the instance of the object on which the shortcode is defined.
+   * @param     string        $callback       The name of the function that defines the shortcode.
+   */
+  public function add_shortcode( $tag, $component, $callback, $priority = 10, $accepted_args = 1 ) {
+      $this->shortcodes = $this->add( $this->shortcodes, $tag, $component, $callback, $priority, $accepted_args );
+  }
 
 	/**
 	 * A utility function that is used to register the actions and hooks into a single
@@ -122,6 +144,10 @@ class Plugin_Name_Loader {
 
 		foreach ( $this->actions as $hook ) {
 			add_action( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
+		}
+
+		foreach ( $this->shortcodes as $hook ) {
+			add_shortcode( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
 		}
 
 	}

--- a/plugin-name/includes/class-plugin-name.php
+++ b/plugin-name/includes/class-plugin-name.php
@@ -173,6 +173,8 @@ class Plugin_Name {
 		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
 		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
 
+		$this->loader->add_shortcode( 'plugin-name-shortcode', $plugin_public, 'plugin_name_shortcode_func' );
+
 	}
 
 	/**

--- a/plugin-name/public/class-plugin-name-public.php
+++ b/plugin-name/public/class-plugin-name-public.php
@@ -100,4 +100,18 @@ class Plugin_Name_Public {
 
 	}
 
+	/**
+	 * Shortcode processing function.
+	 * Shortcode can take arguments like [plugin-name-shortcode argm='123']
+	 */
+	public function plugin_name_shortcode_func($atts) {
+	  $a = shortcode_atts( array(
+			'argm' => '0',
+			), $atts
+		);
+	  return (
+	      $a['argm']
+	  );
+	}
+
 }


### PR DESCRIPTION
Add support for shortcodes in the same manner as filters and actions currently existing on boilerplate.

Also included example function (`plugin_name_shortcode_func`) that can accept shortcode with arguments:
```
[plugin-name-shortcode argm='123']
```