### PR TITLE
jQuery Comments outdated

### DIFF
--- a/plugin-name/admin/js/plugin-name-admin.js
+++ b/plugin-name/admin/js/plugin-name-admin.js
@@ -17,7 +17,7 @@
 	 *
 	 * When the window is loaded:
 	 *
-	 * $( window ).load(function() {
+	 * $( window ).on('load', function() {
 	 *
 	 * });
 	 *


### PR DESCRIPTION
jQuery event-aliases like .load(), .unload() or .error() that all are deprecated since jQuery 1.8.
WP bumped the version a while ago ...