### PR TITLE
jQuery Comments outdated.

### DIFF
--- a/plugin-name/public/js/plugin-name-public.js
+++ b/plugin-name/public/js/plugin-name-public.js
@@ -17,7 +17,7 @@
 	 *
 	 * When the window is loaded:
 	 *
-	 * $( window ).load(function() {
+	 * $( window ).on('load', function() {
 	 *
 	 * });
 	 *


### PR DESCRIPTION
jQuery event-aliases like .load(), .unload() or .error() that all are deprecated since jQuery 1.8.
WP Bumped the version meanwhile...