### PR TITLE
Added support for WordPress built in functions when creating hooks

### DIFF
--- a/plugin-name/includes/class-plugin-name-loader.php
+++ b/plugin-name/includes/class-plugin-name-loader.php
@@ -117,11 +117,11 @@ class Plugin_Name_Loader {
 	public function run() {
 
 		foreach ( $this->filters as $hook ) {
-			add_filter( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
+			add_filter( $hook['hook'], ($hook['component'] ? array( $hook['component'], $hook['callback'] ) : $hook['callback']), $hook['priority'], $hook['accepted_args'] );
 		}
 
 		foreach ( $this->actions as $hook ) {
-			add_action( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
+			add_action( $hook['hook'], ($hook['component'] ? array( $hook['component'], $hook['callback'] ) : $hook['callback']), $hook['priority'], $hook['accepted_args'] );
 		}
 
 	}


### PR DESCRIPTION
Currently a hook defined as below would throw an error under Php 8

$this->loader->add_filter( 'woocommerce_single_product_zoom_enabled', null, '__return_false' );

This change let someone set the hook component as null, thus making built in WordPress functions accessible within the plugin using $this->loader->add_action or $this->loader->add_filter methods