### PR TITLE
Update class-plugin-name.php

### DIFF
--- a/plugin-name/includes/class-plugin-name.php
+++ b/plugin-name/includes/class-plugin-name.php
@@ -139,7 +139,7 @@ class Plugin_Name {
 
 		$plugin_i18n = new Plugin_Name_i18n();
 
-		$this->loader->add_action( 'plugins_loaded', $plugin_i18n, 'load_plugin_textdomain' );
+		$this->loader->add_action( 'init', $plugin_i18n, 'load_plugin_textdomain' );
 
 	}
 


### PR DESCRIPTION
Either we can remove the call to 'load_plugin_textdomain' or can change the hook to init for preventing early loading of translations